### PR TITLE
Updated to add saving the MachineScope in the configuration file.

### DIFF
--- a/CentrifyCLI.cs
+++ b/CentrifyCLI.cs
@@ -313,6 +313,12 @@ Examples:
                     m_config.Profile.URL = URL;
                 }
 
+                // Machine Scope 
+                if (!String.IsNullOrEmpty(MachineScope))
+                {
+                    m_config.Profile.MachineScope = MachineScope;
+                }
+
                 m_config.SwaggerDirectory = !String.IsNullOrEmpty(SwaggerDirectory) ? SwaggerDirectory : Runner.GetUserFilePath(SWAGGER_FILE);
                 m_config.Timeout = Timeout ?? 60;
                 m_config.Silent = silent;
@@ -754,8 +760,8 @@ Examples:
                     {
                         if (MachineIdentity)
                         {
-                            // Get the token
-                            string token = GetTokenFromMachine(timeout, MachineScope ?? "");
+                            // Get the token. Get MachineScope if it is saved in the config and not defined on the command line
+                            string token = GetTokenFromMachine(timeout, MachineScope ?? m_config.Profile.MachineScope ?? "");
 
                             // Init the runner
                             m_runner.InitializeClient(m_config.Profile.URL, token);

--- a/Runner.cs
+++ b/Runner.cs
@@ -65,10 +65,13 @@ namespace CentrifyCLI
             [JsonIgnore]
             public string OAuthToken;
 
+            /// <summary>Machine Scope to use when using DMC</summary>
+            public string MachineScope;
+
             public override string ToString()
             {
                 string name = (String.IsNullOrEmpty(NickName) ? "-default-" : NickName);
-                return $"Profile {name}: URL: '{URL}' AppId: '{OAuthAppId}' User: '{UserName}'";
+                return $"Profile {name}: URL: '{URL}' AppId: '{OAuthAppId}' User: '{UserName}' MachineScope: '{MachineScope}'";
             }
         }
 


### PR DESCRIPTION
Following modifications:

**CentrifyCLI.cs**
- LoadConfig
  - Loads the saved MachineScope if it has been previously saved
- When checking for MachineIdentity, it now will use the following preference:
  - CommandLine provided MachineScope > Config-stored Machine Scope > empty string
  - This is the portion I'm not sure if there is a better way to do it, but through my testing it seems to work as expected.

**Runner.cs**
- listconfig
  - Adds MachineScope to the end of the listed configuration variables
