### PR TITLE
Added installation steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,3 +17,10 @@ ccli builds from either the dotnet command line:
 * dotnet build
 
 or from Visual Studio 2019.  Previous versions may not be able to resolve all dotnet version references.
+
+## Install
+
+* Install .NET Runtime as mentioned [here](https://docs.microsoft.com/en-us/dotnet/core/install/).
+
+* You can install the application from the Releases section.
+


### PR DESCRIPTION
Added installation steps so that customers know they have to install .NET Runtime before installation of ccli binary